### PR TITLE
Updated Browser Icon

### DIFF
--- a/Website-and-Backend/src/main/resources/public/index.html
+++ b/Website-and-Backend/src/main/resources/public/index.html
@@ -8,6 +8,7 @@
     <!-- [if lt IE 9]>
     <script src="stylesheets/html5shiv.js"></script>
     <![endif]-->
+    <link rel="icon" href="images/ethicli-logo.png">
     <link href="stylescripts/reset.css" rel="stylesheet">
     <link href="stylescripts/style.css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
Favicon, an .ico file, wasn't used because StackOverflow just used a .png (we already had the logo)
<img width="342" alt="Screen Shot 2020-06-12 at 7 02 56 PM" src="https://user-images.githubusercontent.com/38482675/84557358-57444d80-acdf-11ea-9692-19f6a2e31c66.png">
