### PR TITLE
Repositioned "read more" links

### DIFF
--- a/Website-and-Backend/src/main/resources/public/stylescripts/script.js
+++ b/Website-and-Backend/src/main/resources/public/stylescripts/script.js
@@ -56,7 +56,7 @@ $(document).ready(function() {
         }
     });
 
-    function mobileNav(){
+    function mobileNav(){ //create mobile menu toggle to show navigation links
         if ($(window).width() <= 768) {
             $("#triplebar").click(function(){
                 $("#navlinks").toggleClass("navClicked");
@@ -66,10 +66,10 @@ $(document).ready(function() {
         }
     }
 
-    $(window).resize(function(){
+    $(window).resize(function(){ //after window is resized, allow menu toggle
         mobileNav();
     })
-    mobileNav();
+    mobileNav(); //allows menu to toggle when starting at a mobile size
 
     $("#mailingListSubmit").click(function(){
         alert("Our mailing list isn't available yet, but thank you for considering to subscribe!");

--- a/Website-and-Backend/src/main/resources/public/stylescripts/script.js
+++ b/Website-and-Backend/src/main/resources/public/stylescripts/script.js
@@ -56,19 +56,20 @@ $(document).ready(function() {
         }
     });
 
-    if ($(window).width() <= 768) {
-        $("#triplebar").click(function(){
-            $("#navlinks").toggleClass("navClicked");
-        })
-    }else{
-        $("#navlinks").removeClass("navClicked");
-    }
-    
-    $(window).resize(function(){
-        if ($(window).width() > 768) {
+    function mobileNav(){
+        if ($(window).width() <= 768) {
+            $("#triplebar").click(function(){
+                $("#navlinks").toggleClass("navClicked");
+            })
+        }else{
             $("#navlinks").removeClass("navClicked");
         }
+    }
+
+    $(window).resize(function(){
+        mobileNav();
     })
+    mobileNav();
 
     $("#mailingListSubmit").click(function(){
         alert("Our mailing list isn't available yet, but thank you for considering to subscribe!");

--- a/Website-and-Backend/src/main/resources/public/stylescripts/style.css
+++ b/Website-and-Backend/src/main/resources/public/stylescripts/style.css
@@ -212,8 +212,9 @@ footer p {
 }
 
 #news article, #featured article {
+    position: relative;
     background: #FFFCF2;
-    padding: 24px;
+    padding: 24px 24px 48px 24px;
     border-radius: 20px;
     width: 31%;
 }
@@ -223,7 +224,9 @@ footer p {
 }
 
 .readmore {
-    text-align: right;
+    position: absolute;
+    bottom: 24px;
+    right: 24px;
     margin-bottom: 0;
 }
 


### PR DESCRIPTION
Repositioned "read more" links
Reformatted menu navigation
<img width="1036" alt="Screen Shot 2020-06-18 at 12 34 48 AM" src="https://user-images.githubusercontent.com/38482675/84991550-84d43100-b0fb-11ea-9c39-0bca5f2bd8b7.png">
