### PR TITLE
Hid sections that don't have data

### DIFF
--- a/Extension/popup.html
+++ b/Extension/popup.html
@@ -47,7 +47,7 @@
                 </div>
             </div>
             <div id="scores" class="tooltip">
-                <div class="label">
+                <div class="label" id="envSection">
                     <p>Environmental Impact</p>
                     <div>
                         <span>
@@ -57,7 +57,7 @@
                         <p><span id="envScore"></span>/10</p>
                     </div>
                 </div>
-                <div class="label">
+                <div class="label" id="laborSection">
                     <p>Labor Practices</p>
                     <div>
                         <span>
@@ -67,7 +67,7 @@
                         <p><span id="laborScore"></span>/10</p>
                     </div>
                 </div>
-                <div class="label">
+                <div class="label" id="animalSection">
                     <p>Animal Welfare</p>
                     <div>
                         <span>
@@ -77,6 +77,7 @@
                         <p><span id="animalScore"></span>/10</p>
                     </div>
                 </div>
+                <p id="noSubscore" style="display:none;">No subscores at this time.</p>
                 <span class="tooltiptext" id="subscoreTip">Scores calculated in these sectors contribute to 
                     the Overall Score, but may not average out to the Overall Score since we are also factoring in 
                     other datasets.

--- a/Extension/popup.js
+++ b/Extension/popup.js
@@ -6,6 +6,33 @@ chrome.runtime.sendMessage({ msgName: "isShoppingPage?" }, function(response) {
 
 function loadExtension() {
     chrome.runtime.sendMessage({ msgName: "whatsMainRating?" }, function(response) {
+        adjustSubscores();
+        function adjustSubscores(){
+            var fullheight = 350;
+            if(response.ethicliStats.environmentScore == 0.0){
+                fullheight= fullheight-50;
+                document.getElementById("envSection").style="display:none;";
+            }
+            if(response.ethicliStats.laborScore == 0.0){
+                fullheight= fullheight-50;
+                document.getElementById("laborSection").style="display:none;";
+            }
+            if(response.ethicliStats.animalsScore == 0.0){
+                fullheight= fullheight-50;
+                document.getElementById("animalSection").style="display:none;";
+            }
+            if(response.ethicliStats.environmentScore == 0.0 &&
+                response.ethicliStats.laborScore == 0.0 &&
+                response.ethicliStats.animalsScore == 0.0
+            ){
+                document.getElementById("noSubscore").style="display:block;";
+                document.getElementById("detailsButton").style="display:none;"
+                fullheight = 160;
+            }
+            var newHeight = "height:"+fullheight+"px;";
+            document.body.style = newHeight;
+        }
+
         var ethicliScore;
         if(response.ethicliStats.overallScore>0){
             ethicliScore = (response.ethicliStats.overallScore).toFixed(1)
@@ -31,7 +58,6 @@ function loadExtension() {
         document.getElementById("laborScoreBar").style.width = laborScore + "px";
         var animalScore = response.ethicliStats.animalsScore*20
         document.getElementById("animalScoreBar").style.width = animalScore + "px";
-
 
         if(document.getElementById("overallScore")!== null){ //checks to see if ID even appears on page
             document.getElementById("overallScore").innerHTML = ethicliScore;

--- a/Extension/stylesheets/stylesheet.css
+++ b/Extension/stylesheets/stylesheet.css
@@ -208,7 +208,7 @@ body {
     margin-left: 24px;
 }
 
-button#detailsButton {
+#detailsButton {
     align-self: flex-end;
     padding: 8px;
 }
@@ -287,6 +287,12 @@ button#detailsButton {
 
 
 /** Typography **/
+
+#noSubscore{
+    font-size: 0.85em;
+    font-weight: bold;
+    color: #E07A5F;
+}
 
 h3 {
     text-align: center;

--- a/Extension/stylesheets/stylesheet.css
+++ b/Extension/stylesheets/stylesheet.css
@@ -288,7 +288,7 @@ body {
 
 /** Typography **/
 
-#noSubscore{
+#noSubscore {
     font-size: 0.85em;
     font-weight: bold;
     color: #E07A5F;


### PR DESCRIPTION
Hid sections that don't have data, and readjusted styling.

With no scores:
<img width="1371" alt="Screen Shot 2020-07-17 at 1 17 13 AM" src="https://user-images.githubusercontent.com/38482675/87764443-40f04c80-c7cb-11ea-8334-0a1b62c345a6.png">

With 1 score:
<img width="1369" alt="Screen Shot 2020-07-17 at 1 17 54 AM" src="https://user-images.githubusercontent.com/38482675/87764497-58c7d080-c7cb-11ea-8b87-04ef9be95daf.png">

With 2 scores:
<img width="1366" alt="Screen Shot 2020-07-17 at 1 18 27 AM" src="https://user-images.githubusercontent.com/38482675/87764540-6e3cfa80-c7cb-11ea-8379-5f7caab5f025.png">

All 3 scores present:
<img width="1368" alt="Screen Shot 2020-07-17 at 1 19 03 AM" src="https://user-images.githubusercontent.com/38482675/87764587-8280f780-c7cb-11ea-9d71-64f74f11fdfd.png">
