### PR TITLE
Only does manipulation of popup.html when score is actually present

### DIFF
--- a/Extension/popup.js
+++ b/Extension/popup.js
@@ -6,7 +6,10 @@ chrome.runtime.sendMessage({ msgName: "isShoppingPage?" }, function(response) {
 
 function loadExtension() {
     chrome.runtime.sendMessage({ msgName: "whatsMainRating?" }, function(response) {
-        adjustSubscores();
+        var ethicliScore = (response.ethicliStats.overallScore).toFixed(1);
+        if (ethicliScore > 0.0) {  // This will need to be updated once negative scores are used as default
+          adjustSubscores();
+        }
         function adjustSubscores(){
             var fullheight = 350;
             if(response.ethicliStats.environmentScore == 0.0){
@@ -32,8 +35,6 @@ function loadExtension() {
             var newHeight = "height:"+fullheight+"px;";
             document.body.style = newHeight;
         }
-
-        var ethicliScore = (response.ethicliStats.overallScore).toFixed(1);
 
         //Change sitename
         document.getElementById("siteurl").innerHTML = response.ethicliStats.name;


### PR DESCRIPTION
The js that manipulates popup.html for score stuff was running even when a score wasn't present. This caused an error that prevented the sitename to be properly updated to "Unavailable" 
![Screen Shot 2020-07-21 at 10 57 23 PM](https://user-images.githubusercontent.com/16740469/88139930-90f15980-cba5-11ea-862a-baa12ba8e8af.png)
