### PR TITLE
Fixed long shopname display problem

### DIFF
--- a/Extension/popup.html
+++ b/Extension/popup.html
@@ -12,7 +12,7 @@
 
 <body style="height:350px;" id="popupMain">
     <div>
-        <p id="sitename">Shop: <span id="siteurl"></span></p>
+        <p id="sitename">Shop: <span id="siteurlcontainer"><span id="siteurl"></span></span></p>
         <div id="menuPanel">
             <div id="menuBacking"></div>
             <button class="tooltip" id="somethingWrong">

--- a/Extension/popup.js
+++ b/Extension/popup.js
@@ -141,20 +141,12 @@ window.onload = function() {
 
 function fadeLongURL(){
     document.getElementById("siteurl").addEventListener("mouseover", function( event ) {
-        var siteurlLength = this.innerHTML.length;
+        var siteurlLength = this.innerHTML.length+16;
         if(siteurlLength > 30){
+            this.style = "margin-left: -"+(siteurlLength)+"px;";
             document.getElementById("siteurlcontainer").style = 
-                "-webkit-mask-image: linear-gradient(to right, black 90%, transparent 100%);\
-                mask-image: linear-gradient(to right, black 90%, transparent 100%);";
-            for(i=0; i<siteurlLength; i++){
-                var diff = i+6; //6 fixes padding
-                this.style = "margin-left: -"+diff+"px;";
-                if(i>(siteurlLength-6)){
-                    document.getElementById("siteurlcontainer").style = 
-                        "-webkit-mask-image: linear-gradient(to right, transparent 0%, black 5%, black 100%, transparent 100%);\
-                        mask-image: linear-gradient(to right, transparent 0%, black 5%, black 100%, transparent 100%)";
-                }
-            }
+                "-webkit-mask-image: linear-gradient(to right, transparent 0%, black 5%, black 100%, transparent 100%);\
+                mask-image: linear-gradient(to right, transparent 0%, black 5%, black 100%, transparent 100%)";
         }
     })
     document.getElementById("siteurl").addEventListener("mouseout", function( event ) {

--- a/Extension/popup.js
+++ b/Extension/popup.js
@@ -140,6 +140,9 @@ function fadeLongURL(){
     document.getElementById("siteurl").addEventListener("mouseover", function( event ) {
         var siteurlLength = this.innerHTML.length;
         if(siteurlLength > 30){
+            document.getElementById("siteurlcontainer").style = 
+                "-webkit-mask-image: linear-gradient(to right, black 90%, transparent 100%);\
+                mask-image: linear-gradient(to right, black 90%, transparent 100%);";
             for(i=0; i<siteurlLength; i++){
                 var diff = i+6; //6 fixes padding
                 this.style = "margin-left: -"+diff+"px;";

--- a/Extension/popup.js
+++ b/Extension/popup.js
@@ -133,6 +133,30 @@ window.onload = function() {
             }
         };
     }
+    fadeLongURL();
+}
+
+function fadeLongURL(){
+    document.getElementById("siteurl").addEventListener("mouseover", function( event ) {
+        var siteurlLength = this.innerHTML.length;
+        if(siteurlLength > 30){
+            for(i=0; i<siteurlLength; i++){
+                var diff = i+6; //6 fixes padding
+                this.style = "margin-left: -"+diff+"px;";
+                if(i>(siteurlLength-6)){
+                    document.getElementById("siteurlcontainer").style = 
+                        "-webkit-mask-image: linear-gradient(to right, transparent 0%, black 5%, black 100%, transparent 100%);\
+                        mask-image: linear-gradient(to right, transparent 0%, black 5%, black 100%, transparent 100%)";
+                }
+            }
+        }
+    })
+    document.getElementById("siteurl").addEventListener("mouseout", function( event ) {
+        this.style = "margin-left: 0px;";
+        document.getElementById("siteurlcontainer").style = 
+            "-webkit-mask-image: linear-gradient(to right, black 90%, transparent 100%);\
+            mask-image: linear-gradient(to right, black 90%, transparent 100%)";
+    })
 }
 
 function urlToCompanyName(url) {

--- a/Extension/popup.js
+++ b/Extension/popup.js
@@ -133,7 +133,10 @@ window.onload = function() {
             }
         };
     }
-    fadeLongURL();
+
+    if(document.getElementById("sitename") != null){
+        fadeLongURL();
+    }
 }
 
 function fadeLongURL(){

--- a/Extension/popupNoRating.html
+++ b/Extension/popupNoRating.html
@@ -12,7 +12,7 @@
 
 <body style="height:280px;" id="popupNoRating">
     <div>
-        <p id="sitename">Shop: <span id="siteurl"></span></p>
+        <p id="sitename">Shop: <span id="siteurlcontainer"><span id="siteurl"></span></span></p>
         <div id="menuPanel">
             <div id="menuBacking"></div>
             <button class="tooltip" id="somethingWrong">

--- a/Extension/stylesheets/stylesheet.css
+++ b/Extension/stylesheets/stylesheet.css
@@ -381,6 +381,31 @@ body {
     font-size: 0.75em;
     font-weight: bold;
     z-index: 2;
+    
+}
+
+#siteurlcontainer {
+    display: inline-block;
+    overflow-x: hidden;
+    max-width: 190px;
+    white-space: pre;
+    height: 10px;
+
+    -webkit-mask-image: linear-gradient(to right, black 90%, transparent 100%);
+    mask-image: linear-gradient(to right, black 90%, transparent 100%);
+}
+
+#siteurl {
+    display: block;
+    cursor: default;
+    -webkit-transition: all 200ms cubic-bezier(0.815, 0.015, 0.750, 0.750);
+    -moz-transition: all 200ms cubic-bezier(0.815, 0.015, 0.750, 0.750);
+    -o-transition: all 200ms cubic-bezier(0.815, 0.015, 0.750, 0.750);
+    transition: all 200ms cubic-bezier(0.815, 0.015, 0.750, 0.750);
+    -webkit-transition-timing-function: cubic-bezier(0.815, 0.015, 0.750, 0.750);
+    -moz-transition-timing-function: cubic-bezier(0.815, 0.015, 0.750, 0.750);
+    -o-transition-timing-function: cubic-bezier(0.815, 0.015, 0.750, 0.750);
+    transition-timing-function: cubic-bezier(0.815, 0.015, 0.750, 0.750);
 }
 
 #noSubscore {

--- a/Extension/stylesheets/stylesheet.css
+++ b/Extension/stylesheets/stylesheet.css
@@ -387,7 +387,7 @@ body {
 #siteurlcontainer {
     display: inline-block;
     overflow-x: hidden;
-    max-width: 190px;
+    width: 190px;
     white-space: pre;
     height: 10px;
 


### PR DESCRIPTION
Shop name now scrolls on hover to show entire name

Short Shopname: 
<img width="1134" alt="Screen Shot 2020-08-17 at 12 52 19 AM" src="https://user-images.githubusercontent.com/38482675/90371491-ea716a80-e023-11ea-9aa0-1308edcdf3bf.png">

Long Shopname (off and on hover):
<img width="1150" alt="Screen Shot 2020-08-17 at 12 52 51 AM" src="https://user-images.githubusercontent.com/38482675/90371547-fc530d80-e023-11ea-82c6-315f629ac3db.png">
<img width="1150" alt="Screen Shot 2020-08-17 at 12 53 07 AM" src="https://user-images.githubusercontent.com/38482675/90371589-05dc7580-e024-11ea-8cb2-5d5cc20a4b27.png">
