### PR TITLE
Security Feature Added Needs Mongo Added Before It Will Work

### DIFF
--- a/Website-and-Backend/pom.xml
+++ b/Website-and-Backend/pom.xml
@@ -108,6 +108,10 @@
       <artifactId>appengine-api-1.0-sdk</artifactId>
       <version>1.9.59</version>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
   </dependencies>
 
   <build>
@@ -124,7 +128,6 @@
               </execution>
           </executions>
       </plugin>
-
       <plugin>
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
@@ -137,5 +140,4 @@
 
     </plugins>
   </build>
-
 </project>

--- a/Website-and-Backend/src/main/java/com/example/appengine/springboot/SecurityConfig.java
+++ b/Website-and-Backend/src/main/java/com/example/appengine/springboot/SecurityConfig.java
@@ -1,0 +1,25 @@
+package com.example.appengine.springboot;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@Configuration
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+  // Authentication : User --> Roles
+  protected void configure(AuthenticationManagerBuilder auth)
+      throws Exception {
+    auth.inMemoryAuthentication().withUser("<user-username>").password("{noop}<user-password>")
+        .roles("USER").and().withUser("<admin-username>").password("{noop}<admin-password>")
+        .roles("USER", "ADMIN");
+  }
+
+  // Authorization : Role -> Access
+  protected void configure(HttpSecurity http) throws Exception {
+    http.httpBasic().and().authorizeRequests().antMatchers("/Advertisement/getByProductTags", "/Advertisement/getById", "/Advertisement/tagRegex", "/score/**")
+        .hasRole("USER").antMatchers("/**").hasRole("ADMIN").and()
+        .csrf().disable().headers().frameOptions().disable();
+  }
+
+}


### PR DESCRIPTION
First things first, this is just a draft. It will not work without the AdvertisementController in the MongoDB PR. I have tested it with the AdvertisementController and it works perfectly. I just wanted to put it up so you could take a look at it. 

_User Permissions:_ "user" is in reference to the permissions granted to the extension. This level of permissions can also be accessed from postman or a browser, however it will only work if the proper username and password is attached to the api call. "user"s have permissions to "/Advertisement/getByProductTags", "/Advertisement/getById", "/Advertisement/tagRegex", "/score/**". 

_Admin Permisions:_ "admin" is in reference to whoever (Amy) is editing the Advertising data. They have permissions for all calls. 

_SecurityConfig():_ This sets up the configurations for our security authentication. 

_.configure(AuthenticationManagerBuilder auth):_ Authenticates the username and password, assigns them roles: "USER", "ADMIN",.. Here is where you enter the <username> and <password>, this will be required before deploying.

_configure(HttpSecurity http):_ Authorizes role and ives it access. In other words, it defines what permission the role "USER" and "ADMIN" might have. If you want to add/remove permissions from a role, here is where you do it.
